### PR TITLE
Wait for the new child to be ready.

### DIFF
--- a/child/child.go
+++ b/child/child.go
@@ -3,16 +3,26 @@ package child
 import (
 	"errors"
 	"os"
+	"strconv"
 	"syscall"
 )
 
 var (
 	// ErrZeroMasterPID returned when given master PID is zero
-	ErrZeroMasterPID = errors.New("master PID is zero")
+	ErrZeroMasterPID = errors.New("master PID is zero or empty")
 )
 
 // NotifyMaster notifies the master about child readyness
-func NotifyMaster(masterPID int) error {
+func NotifyMaster() error {
+	pidStr := os.Getenv("SOCKETMASTER_PID")
+	if pidStr == "" {
+		return ErrZeroMasterPID
+	}
+
+	masterPID, err := strconv.Atoi(pidStr)
+	if err != nil {
+		return err
+	}
 	if masterPID == 0 {
 		return ErrZeroMasterPID
 	}

--- a/child/child.go
+++ b/child/child.go
@@ -1,0 +1,26 @@
+package child
+
+import (
+	"errors"
+	"os"
+	"syscall"
+)
+
+var (
+	// ErrZeroMasterPID returned when given master PID is zero
+	ErrZeroMasterPID = errors.New("master PID is zero")
+)
+
+// NotifyMaster notifies the master about child readyness
+func NotifyMaster(masterPID int) error {
+	if masterPID == 0 {
+		return ErrZeroMasterPID
+	}
+
+	proc, err := os.FindProcess(masterPID)
+	if err != nil {
+		return err
+	}
+
+	return proc.Signal(syscall.SIGUSR1)
+}

--- a/man/socketmaster.1.ronn
+++ b/man/socketmaster.1.ronn
@@ -83,26 +83,18 @@ to send `SIGUSR1` before killing the old one.
 
 Note that `-wait-child-notif` still respect `-start` argument.
 
-In order to use this feature, the app server need to do these:
-- add support for `socketmaster-pid` command line argument
-  `socketmaster` will start the app server with `socketmaster-id {PID_OF_SOCKETMASTER}`
-  argument
-- Send `SIGUSR1` signal after the appserver is ready
+In order to use this feature, the app server need to do this:
+- read `SOCKETMASTER_PID` environment variable to get `socketmaster` process ID
+- Send `SIGUSR1` signal after the appserver is ready to the `socketmaster`
 
 *Example in Go*
-
-add support for `socketmaster-pid` command line argument
-```go
-flag.IntVar(&socketmasterPID, "socketmaster-pid", 0, "pid of the socketmaster")
-flag.Parse()
-```
 
 Send `SIGUSR1` signal after the appserver is ready
 ```go
 import (
   "github.com/tokopedia/socketmaster/child"
 )
-go child.NotifyMaster(socketmasterPID)
+go child.NotifyMaster()
 ```
 
 ## RELATED PROJECTS

--- a/man/socketmaster.1.ronn
+++ b/man/socketmaster.1.ronn
@@ -37,6 +37,11 @@ and can keep your file-descriptor indefinitely open.
     Sets the child process's uid/gid to the given user (looked up in /etc/passwd).
     This command only works when socketmaster is run as root.
 
+  * `wait-child-notif`=boolean (default: false):
+    If true, `socketmaster` will wait for the newly created process to send `SIGUSR1` before
+    killing the old one. More details below. It still respect `-start` argument.
+    Details [below](#wait-child-notif)
+
 ## HOW IT WORKS
 
 On start:
@@ -70,6 +75,35 @@ On SIGHUP, socketmaster starts a new child process, waits for -start and sends a
 HUP to the old process.
 
 SIGINT, SIGTERM and SIGQUIT are forwarded to the child processes.
+
+## Wait Child Notif
+
+When activated using `-wait-child-notif` flag, `socketmaster` will wait for the newly created process
+to send `SIGUSR1` before killing the old one.
+
+Note that `-wait-child-notif` still respect `-start` argument.
+
+In order to use this feature, the app server need to do these:
+- add support for `socketmaster-pid` command line argument
+  `socketmaster` will start the app server with `socketmaster-id {PID_OF_SOCKETMASTER}`
+  argument
+- Send `SIGUSR1` signal after the appserver is ready
+
+*Example in Go*
+
+add support for `socketmaster-pid` command line argument
+```go
+flag.IntVar(&socketmasterPID, "socketmaster-pid", 0, "pid of the socketmaster")
+flag.Parse()
+```
+
+Send `SIGUSR1` signal after the appserver is ready
+```go
+import (
+  "github.com/tokopedia/socketmaster/child"
+)
+go child.NotifyMaster(socketmasterPID)
+```
 
 ## RELATED PROJECTS
 

--- a/process_group.go
+++ b/process_group.go
@@ -49,6 +49,9 @@ func (self *ProcessGroup) StartProcess() (process *os.Process, err error) {
 	}
 
 	env := append(os.Environ(), "EINHORN_FDS=3")
+	if self.waitChildNotif {
+		env = append(env, fmt.Sprintf("SOCKETMASTER_PID=%d", os.Getpid()))
+	}
 
 	procAttr := &os.ProcAttr{
 		Env:   env,
@@ -67,10 +70,6 @@ func (self *ProcessGroup) StartProcess() (process *os.Process, err error) {
 	}
 
 	args := append([]string{self.commandPath}, flag.Args()...)
-	if self.waitChildNotif {
-		args = append(args, "-socketmaster-pid")
-		args = append(args, fmt.Sprintf("%d", os.Getpid()))
-	}
 
 	log.Println("Starting", self.commandPath, args)
 	process, err = os.StartProcess(self.commandPath, args, procAttr)


### PR DESCRIPTION
Wait for the new child notification about it's readyness
before killing the old one.

Child send the notifcation to socketmaster using SIGUSR1 signal.

**Why we need this feature**

`socketmaster` currently wait for `-start` milliseconds before killing the old process.
It doesn't care whether the new process is ready or not.

It created downtime when the new process took a long time to initialise.

One of the solution is to set `-start` argument to a very long time. But i don't think that it is the good solution with these reasons:
- `race condition` like this should not be fixed with timing, it should be fixed with coordination or lock in case of single process
- what if we want the deployment to be finished as soon as possible
- what if for some reason, the initialise still take longer time
- it simply not elegant

**use case**

`feeds` got this issue, i also got info that some other teams also face same issue.

**added description on readme**
## Wait Child Notif

When activated using `-wait-child-notif` flag, `socketmaster` will wait for the newly created process
to send `SIGUSR1` before killing the old one.

Note that `-wait-child-notif` still respect `-start` argument.

In order to use this feature, the app server need to do these:
- ~add support for `socketmaster-pid` command line argument
  `socketmaster` will start the app server with `socketmaster-id {PID_OF_SOCKETMASTER}`
  argument~
- read `SOCKETMASTER_PID` environment variable to get `socketmaster` process ID
- Send `SIGUSR1` signal after the appserver is ready

*Example in Go*

~add support for `socketmaster-pid` command line argument~

Send `SIGUSR1` signal after the appserver is ready
```go
import (
  "github.com/tokopedia/socketmaster/child"
)
go child.NotifyMaster()
```
